### PR TITLE
Add real-time stock validation for manual RIS entry

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -207,6 +207,12 @@ Route::middleware(['auth:sanctum', config('jetstream.auth_session'), 'verified']
         // NEW: Manual RIS Entry Route (Admin/CAO only)
         Route::post('/ris/manual-entry', [RisSlipController::class, 'storeManual'])->name('ris.store-manual');
 
+        // web.php (inside your admin-cao group)
+        Route::post('/ris/validate-manual-stock', [RisSlipController::class, 'validateManualStock'])
+            ->name('ris.validate-manual-stock')
+            ->middleware(['auth','admin-cao']);
+
+
 
 
 


### PR DESCRIPTION
Introduces an endpoint and frontend logic to validate available supply stock based on the selected RIS date during manual RIS entry. The controller now calculates availability by summing receipts and issues up to the RIS date, and the UI updates available quantities dynamically as the date or supply selection changes. Route protection is enforced for admin/CAO roles.