### PR TITLE
Add month filter to stock and supply ledger card views

### DIFF
--- a/resources/views/stock-cards/show.blade.php
+++ b/resources/views/stock-cards/show.blade.php
@@ -54,6 +54,7 @@
                             <form method="GET" action="{{ route('stock-cards.show', $supply->supply_id) }}"
                                 class="flex space-x-2">
                                 <input type="hidden" name="fund_cluster" value="{{ $fundCluster }}">
+                                <input type="hidden" name="month" value="{{ $selectedMonth }}">
                                 <select name="year" onchange="this.form.submit()"
                                     class="px-4 py-2 rounded-lg text-sm
                                         bg-white text-[#a01b1a] border border-[#a01b1a]
@@ -67,10 +68,32 @@
                                 </select>
                             </form>
 
+                            <!-- Month Selector (NEW) -->
+                            @if($availableMonths->isNotEmpty())
+                                <form method="GET" action="{{ route('stock-cards.show', $supply->supply_id) }}"
+                                    class="flex space-x-2">
+                                    <input type="hidden" name="fund_cluster" value="{{ $fundCluster }}">
+                                    <input type="hidden" name="year" value="{{ $selectedYear }}">
+                                    <select name="month" onchange="this.form.submit()"
+                                        class="px-4 py-2 rounded-lg text-sm
+                                            bg-white text-[#a01b1a] border border-[#a01b1a]
+                                            focus:outline-none focus:ring-2 focus:ring-[#a01b1a]">
+                                        <option value="">All Months</option>
+                                        @foreach ($availableMonths as $month)
+                                            <option value="{{ $month['value'] }}"
+                                                {{ $selectedMonth == $month['value'] ? 'selected' : '' }}>
+                                                {{ $month['name'] }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </form>
+                            @endif
+
                             <!-- Fund Cluster Selector -->
                             <form method="GET" action="{{ route('stock-cards.show', $supply->supply_id) }}"
                                 class="flex space-x-2">
                                 <input type="hidden" name="year" value="{{ $selectedYear }}">
+                                <input type="hidden" name="month" value="{{ $selectedMonth }}">
                                 <select name="fund_cluster" onchange="this.form.submit()"
                                     class="px-4 py-2 rounded-lg text-sm
                                         bg-white text-[#a01b1a] border border-[#a01b1a]
@@ -83,7 +106,6 @@
                                     @endforeach
                                 </select>
                             </form>
-
                         </div>
                     </div>
                 </div>

--- a/resources/views/supply-ledger-cards/show.blade.php
+++ b/resources/views/supply-ledger-cards/show.blade.php
@@ -59,6 +59,7 @@
                             <form method="GET" action="{{ route('supply-ledger-cards.show', $supply->supply_id) }}"
                                 class="flex space-x-2">
                                 <input type="hidden" name="fund_cluster" value="{{ $fundCluster }}">
+                                <input type="hidden" name="month" value="{{ $selectedMonth }}">
                                 <select name="year" onchange="this.form.submit()"
                                     class="px-4 py-2 rounded-lg text-sm
                                         bg-white text-[#a01b1a] border border-[#a01b1a]
@@ -72,10 +73,32 @@
                                 </select>
                             </form>
 
+                            <!-- Month Selector (NEW) -->
+                            @if($availableMonths->isNotEmpty())
+                                <form method="GET" action="{{ route('supply-ledger-cards.show', $supply->supply_id) }}"
+                                    class="flex space-x-2">
+                                    <input type="hidden" name="fund_cluster" value="{{ $fundCluster }}">
+                                    <input type="hidden" name="year" value="{{ $selectedYear }}">
+                                    <select name="month" onchange="this.form.submit()"
+                                        class="px-4 py-2 rounded-lg text-sm
+                                            bg-white text-[#a01b1a] border border-[#a01b1a]
+                                            focus:outline-none focus:ring-2 focus:ring-[#a01b1a]">
+                                        <option value="">All Months</option>
+                                        @foreach ($availableMonths as $month)
+                                            <option value="{{ $month['value'] }}"
+                                                {{ $selectedMonth == $month['value'] ? 'selected' : '' }}>
+                                                {{ $month['name'] }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </form>
+                            @endif
+
                             <!-- Fund Cluster Selector -->
                             <form method="GET" action="{{ route('supply-ledger-cards.show', $supply->supply_id) }}"
                                 class="flex space-x-2">
                                 <input type="hidden" name="year" value="{{ $selectedYear }}">
+                                <input type="hidden" name="month" value="{{ $selectedMonth }}">
                                 <select name="fund_cluster" onchange="this.form.submit()"
                                     class="px-4 py-2 rounded-lg text-sm
                                         bg-white text-[#a01b1a] border border-[#a01b1a]


### PR DESCRIPTION
Introduces a month selector for both stock card and supply ledger card pages, allowing users to filter transactions by month in addition to year and fund cluster. Controller logic and view templates were updated to support the new filter, including calculation of available months and correct handling of beginning balances and transaction periods.